### PR TITLE
Use env config for Map envs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/hii-client",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/ui-component-library": "^0.5.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "User interface for HII project",
   "homepage": "https://digicatapult.github.io/hii-client/",
   "main": "src/index.js",

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -10,6 +10,7 @@ import {
   ListCard,
 } from '@digicatapult/ui-component-library'
 
+import { MAPBOX_TOKEN, MAPBOX_STYLE } from '../utils/env'
 import Dialog from './components/Dialog'
 import LogoPNG from '../assets/images/hii-logo.png'
 import LogoWebP from '../assets/images/hii-logo.webp'
@@ -203,13 +204,13 @@ export default function Home() {
       </Grid.Panel>
       <Grid.Panel area="main" style={{ position: 'relative' }}>
         <Map
-          token={process.env.MAPBOX_TOKEN}
+          token={MAPBOX_TOKEN}
           sourceJson={filteredGeoJson}
           initialState={{
             height: '100%',
             width: '100%',
             zoom: 5.5,
-            style: process.env.MAPBOX_STYLE,
+            style: MAPBOX_STYLE,
           }}
           cluster={true}
           clusterOptions={{


### PR DESCRIPTION
Will make https://digicatapult.github.io/hii-client/ have correct styling!

Map envs were using `process.env` directly rather than `env.js` (which checks `Window.config` and has defaults)