### PR TITLE
Fix focus shift on search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/hii-client",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@digicatapult/ui-component-library": "^0.6.5",
+        "@digicatapult/ui-component-library": "^0.7.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "User interface for HII project",
   "homepage": "https://digicatapult.github.io/hii-client/",
   "main": "src/index.js",

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -96,7 +96,6 @@ const formatProjectName = (name) => name.toLowerCase().replace(/\s/g, '_')
 
 export default function Home() {
   const [search, setSearch] = useState([])
-  const [showDialog, setShowDialog] = useState(false)
   const [selectedFeature, setSelectedFeature] = useState(null)
   const [filter, setFilter] = useState(null)
   const [zoomLocation, setZoomLocation] = useState(null)
@@ -150,10 +149,17 @@ export default function Home() {
     }
   }, [search, filter])
 
-  // clear selected feature on dialog close
   useEffect(() => {
-    if (!showDialog) setSelectedFeature(null)
-  }, [showDialog])
+    const selectedInView =
+      selectedFeature !== null &&
+      !!filteredGeoJson.features.find(
+        ({ properties: { id } }) => id === selectedFeature.properties.id
+      )
+
+    if (!selectedInView) {
+      setSelectedFeature(null)
+    }
+  }, [filteredGeoJson, selectedFeature])
 
   return (
     <FullScreenGrid
@@ -193,10 +199,7 @@ export default function Home() {
             placeholder="Search"
             color="#216968"
             background="white"
-            onSubmit={(s) => {
-              setSearch(s)
-              setShowDialog(false)
-            }}
+            onSubmit={setSearch}
           />
         </SearchWrapper>
       </Grid.Panel>
@@ -255,7 +258,6 @@ export default function Home() {
                   feature.geometry.coordinates[0],
                   feature.geometry.coordinates[1],
                 ])
-                setShowDialog(true)
               }}
             />
           ))}
@@ -285,16 +287,16 @@ export default function Home() {
             pointStrokeWidth: 1,
             onPointClick: (feature) => {
               setSelectedFeature(feature)
-              setShowDialog(true)
             },
             onClickZoomIn: 11,
           }}
         />
-        <Dialog
-          open={showDialog}
-          setOpen={setShowDialog}
-          feature={selectedFeature}
-        />
+        {selectedFeature === null ? null : (
+          <Dialog
+            onClose={() => setSelectedFeature(null)}
+            feature={selectedFeature}
+          />
+        )}
       </Grid.Panel>
     </FullScreenGrid>
   )

--- a/src/pages/components/Dialog.js
+++ b/src/pages/components/Dialog.js
@@ -15,25 +15,20 @@ const Wrapper = styled.div`
   left: 5ch;
 `
 
-export default function Dialog({ open, setOpen, feature }) {
+export default function Dialog({ onClose, feature }) {
   const properties = feature?.properties
 
   const dialogRef = useRef(null)
   useEffect(() => {
     const dialog = dialogRef.current
-    if (open) {
-      dialog.show()
-    } else {
-      dialog.close()
-    }
+    dialog.show()
+  }, [])
 
-    const listener = () => {
-      setOpen(false)
-    }
-    dialog?.addEventListener('close', listener)
-
-    return () => dialog?.removeEventListener('close', listener)
-  }, [open, setOpen])
+  useEffect(() => {
+    const dialog = dialogRef.current
+    dialog?.addEventListener('close', onClose)
+    return () => dialog?.removeEventListener('close', onClose)
+  }, [onClose])
 
   return (
     <Wrapper>


### PR DESCRIPTION
This change improves a few things about how dialogs are handled. Most importantly it changes the behaviour when the search or filters change to prevent the focus shifting. Note this is achieved via a currious side-effect so this could be considered a hack. The changes:

* reduce number of state elements in Home as there were redundencies
* fix up effects in Dialog so were only calling show/close if we need to
* Don't render the dialog if we don't have to. This is a hack to prevent the focus change behaviour
* only deselect the selectedFeature on search change if the new list does not contain the selected feature

Basically the issue occurs because the dialog returns focus to the previous selected input that triggered it's opening on close. That is the button list of cards. There doesn't seem to be a way of preventing this without moving away from html dialog in the component library
