### PR TITLE
Revert "Change BrowserRouter to HashRouter"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.2",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/hii-client",
-      "version": "0.15.2",
+      "version": "0.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/ui-component-library": "^0.7.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.2",
+  "version": "0.15.1",
   "description": "User interface for HII project",
   "homepage": "https://digicatapult.github.io/hii-client/",
   "main": "src/index.js",

--- a/src/utils/Router.js
+++ b/src/utils/Router.js
@@ -1,15 +1,15 @@
 import React from 'react'
-import { Routes, Route, HashRouter } from 'react-router-dom'
+import { Routes, Route, BrowserRouter } from 'react-router-dom'
 import Home from '../pages/Home'
 import { PUBLIC_BASE_PATH } from './env'
 
 export default function Router() {
   return (
-    <HashRouter basename={PUBLIC_BASE_PATH}>
+    <BrowserRouter basename={PUBLIC_BASE_PATH}>
       <Routes>
         <Route exec path={'/'} element={<Home />} />
         <Route exec path={':projectId'} element={<Home />} />
       </Routes>
-    </HashRouter>
+    </BrowserRouter>
   )
 }


### PR DESCRIPTION
Reverts digicatapult/hii-client#41 as Github Pages isn't loading the index page with `HashRouter`, suspected additional changes needed but revert for now to keep the page working. 