### PR TITLE
Change Help/Key icon from circle to a square

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/hii-client",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/ui-component-library": "^0.7.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/hii-client",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/ui-component-library": "^0.7.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "User interface for HII project",
   "homepage": "https://digicatapult.github.io/hii-client/",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "User interface for HII project",
   "homepage": "https://digicatapult.github.io/hii-client/",
   "main": "src/index.js",

--- a/src/pages/components/Key.js
+++ b/src/pages/components/Key.js
@@ -66,7 +66,7 @@ export default function Key({}) {
           width="2.5em"
           closeBackground="#27847A"
           openBackground="#000"
-          borderRadius="1.25em"
+          borderRadius="0em"
           fontColor="#FFF"
           fontWeight="bold"
           margin="2em"


### PR DESCRIPTION
Addresses bug [HII-74](https://digicatapult.atlassian.net/jira/software/projects/HII/boards/148/backlog?selectedIssue=HII-74), the round help/key icon has been changed to square to avoid confusion with map marker points.

Before:

<img width="136" alt="Screenshot 2023-01-23 at 11 40 06" src="https://user-images.githubusercontent.com/35331926/214037224-c41a51e2-b95c-4ef7-9f16-680fa44befd5.png"><img width="136" alt="Screenshot 2023-01-23 at 11 40 56" src="https://user-images.githubusercontent.com/35331926/214037281-30bdec0f-7b54-40fa-b2f4-adc2b1137d88.png">

After:

<img width="136" alt="Screenshot 2023-01-23 at 11 40 21" src="https://user-images.githubusercontent.com/35331926/214037325-8b9f942b-4856-4404-8702-14cd7bb849ac.png"><img width="136" alt="Screenshot 2023-01-23 at 11 40 44" src="https://user-images.githubusercontent.com/35331926/214037346-91eee446-fa27-44c7-b9cf-fac92a608792.png">

