### PR TITLE
Only show relevant key categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/hii-client",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/ui-component-library": "^0.7.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "User interface for HII project",
   "homepage": "https://digicatapult.github.io/hii-client/",
   "main": "src/index.js",

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -371,7 +371,7 @@ export default function Home() {
             />
           </Suspense>
         )}
-        <Key projects={options.projects} />
+        <Key projectTypes={options.projects} />
       </Grid.Panel>
     </FullScreenGrid>
   )

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -371,7 +371,7 @@ export default function Home() {
             />
           </Suspense>
         )}
-        <Key />
+        <Key projects={options.projects} />
       </Grid.Panel>
     </FullScreenGrid>
   )

--- a/src/pages/components/Key.js
+++ b/src/pages/components/Key.js
@@ -39,25 +39,30 @@ const Row = styled.div`
   }
 `
 
-const Rows = () => (
+const Rows = ({ projects }) => (
   <RowWrapper>
-    {Object.entries(projectColours).map(([key, value]) => (
-      <Row key={key} color={value}>
-        {key}
-      </Row>
-    ))}
+    {projects != undefined && projects != null && projects.length > 0
+      ? projects.map((project) => (
+          <Row key={project.label} color={project.color}>
+            {project.label}
+          </Row>
+        ))
+      : Object.entries(projectColours).map(([key, value]) => (
+          <Row key={key} color={value}>
+            {key}
+          </Row>
+        ))}
   </RowWrapper>
 )
 
-export default function Key({}) {
+export default function Key({ projects }) {
   const [isOpen, setIsOpen] = useState(false)
   const onClick = () => setIsOpen(!isOpen)
-
   return (
     <Wrapper>
       {isOpen && (
         <HelpContainer width="25ch" background="#FFF">
-          <Rows />
+          <Rows projects={projects} />
         </HelpContainer>
       )}
       <ButtonWrapper>

--- a/src/pages/components/Key.js
+++ b/src/pages/components/Key.js
@@ -39,12 +39,14 @@ const Row = styled.div`
   }
 `
 
-const Rows = ({ projects }) => (
+const Rows = ({ projectTypes }) => (
   <RowWrapper>
-    {projects != undefined && projects != null && projects.length > 0
-      ? projects.map((project) => (
-          <Row key={project.label} color={project.color}>
-            {project.label}
+    {projectTypes != undefined &&
+    projectTypes != null &&
+    projectTypes.length > 0
+      ? projectTypes.map((projectType) => (
+          <Row key={projectType.label} color={projectType.color}>
+            {projectType.label}
           </Row>
         ))
       : Object.entries(projectColours).map(([key, value]) => (
@@ -55,14 +57,14 @@ const Rows = ({ projects }) => (
   </RowWrapper>
 )
 
-export default function Key({ projects }) {
+export default function Key({ projectTypes }) {
   const [isOpen, setIsOpen] = useState(false)
   const onClick = () => setIsOpen(!isOpen)
   return (
     <Wrapper>
       {isOpen && (
         <HelpContainer width="25ch" background="#FFF">
-          <Rows projects={projects} />
+          <Rows projectTypes={projectTypes} />
         </HelpContainer>
       )}
       <ButtonWrapper>


### PR DESCRIPTION
Relates to [this issue](https://digicatapult.atlassian.net/jira/software/projects/HII/boards/148/backlog?selectedIssue=HII-76), only categories that are being used are now shown. If for any reason no project categories are passed to the key it will default the the original categories as a fallback.

Before:
<img width="260" alt="Screenshot 2023-01-26 at 11 16 58" src="https://user-images.githubusercontent.com/35331926/214823464-575aa9d9-c370-419b-8fa8-72b04d2658f5.png">

After:
<img width="260" alt="Screenshot 2023-01-26 at 11 15 57" src="https://user-images.githubusercontent.com/35331926/214823492-00359d10-d524-4cde-84c1-a64206a9b792.png">




