### PR TITLE
Change roll-up colour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/hii-client",
-      "version": "0.15.5",
+      "version": "0.15.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/ui-component-library": "^0.7.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "User interface for HII project",
   "homepage": "https://digicatapult.github.io/hii-client/",
   "main": "src/index.js",

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -343,7 +343,7 @@ export default function Home() {
             }}
             cluster={true}
             clusterOptions={{
-              clusterColor: '#216968',
+              clusterColor: '#979797',
               clusterRadius: 14,
               clusterMaxZoom: 10,
             }}


### PR DESCRIPTION
Relates to [this issue](https://digicatapult.atlassian.net/jira/software/projects/HII/boards/148/backlog?selectedIssue=HII-75) and changes the aggregated roll-up colour.


Before:
<img width="254" alt="Screenshot 2023-01-26 at 11 49 40" src="https://user-images.githubusercontent.com/35331926/214828950-c019d9b5-61cf-4ef6-be27-b108c07068dd.png">

After:
<img width="254" alt="Screenshot 2023-01-26 at 11 50 22" src="https://user-images.githubusercontent.com/35331926/214828969-047ea7fe-3fb7-44ca-a036-20dd51957438.png">

