### PR TITLE
Use URL parameter instead of Route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/hii-client",
-      "version": "0.15.6",
+      "version": "0.15.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/ui-component-library": "^0.7.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "User interface for HII project",
   "homepage": "https://digicatapult.github.io/hii-client/",
   "main": "src/index.js",

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -6,7 +6,7 @@ import React, {
   lazy,
   Suspense,
 } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import styled from 'styled-components'
 import {
   Grid,
@@ -150,10 +150,11 @@ export default function Home() {
   const [selectedFeature, setSelectedFeature] = useState(null)
   const [filter, setFilter] = useState({ projects: [], hydrogens: [] })
   const [zoomLocation, setZoomLocation] = useState(null)
-  const navigate = useNavigate()
   const listWrapperRef = useRef({})
   const options = filterOptions()
-  const { projectId: paramId } = useParams()
+
+  const [searchParams, setSearchParams] = useSearchParams()
+  const paramId = searchParams.get('projectId')
 
   useEffect(() => {
     if (paramId) {
@@ -318,7 +319,7 @@ export default function Home() {
                 feature.properties['Project Type']
               )}
               onClick={() => {
-                navigate(`/${feature.properties.id}`, { replace: true })
+                setSearchParams({ projectId: feature.properties.id })
                 setSelectedFeature(feature)
                 setZoomLocation([
                   feature.geometry.coordinates[0],
@@ -353,7 +354,7 @@ export default function Home() {
               pointStrokeColor: '#8a8988',
               pointStrokeWidth: 1,
               onPointClick: (feature) => {
-                navigate(`/${feature.properties.id}`, { replace: true })
+                setSearchParams({ projectId: feature.properties.id })
                 setSelectedFeature(feature)
               },
               onClickZoomIn: 11,

--- a/src/utils/Router.js
+++ b/src/utils/Router.js
@@ -8,7 +8,6 @@ export default function Router() {
     <BrowserRouter basename={PUBLIC_BASE_PATH}>
       <Routes>
         <Route exec path={'/'} element={<Home />} />
-        <Route exec path={':projectId'} element={<Home />} />
       </Routes>
     </BrowserRouter>
   )


### PR DESCRIPTION
This addresses the [404 issue](https://digicatapult.atlassian.net/jira/software/projects/HII/boards/148/backlog?selectedIssue=HII-73) and replaces project `Routes` with URL parameters instead. This has been tested locally, but needs to be deployed to Github Pages to check it works there.
Before:
`https://digicatapult.github.io/hii-client/5bdd62f9-34c8-4c91-a352-029d732d3def`

After:
`https://digicatapult.github.io/hii-client/?projectId=5bdd62f9-34c8-4c91-a352-029d732d3def`
