### PR TITLE
Fixes Key colour regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/hii-client",
-      "version": "0.15.7",
+      "version": "0.15.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/ui-component-library": "^0.7.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/hii-client",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "User interface for HII project",
   "homepage": "https://digicatapult.github.io/hii-client/",
   "main": "src/index.js",

--- a/src/pages/components/Key.js
+++ b/src/pages/components/Key.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { HelpContainer, ToggleButton } from '@digicatapult/ui-component-library'
 
-import { projectColours } from '../../utils/theme'
+import { projectColours, getProjectTypeColour } from '../../utils/theme'
 
 const Wrapper = styled.div`
   position: absolute;
@@ -45,7 +45,10 @@ const Rows = ({ projectTypes }) => (
     projectTypes != null &&
     projectTypes.length > 0
       ? projectTypes.map((projectType) => (
-          <Row key={projectType.label} color={projectType.color}>
+          <Row
+            key={projectType.label}
+            color={getProjectTypeColour(projectType.label)}
+          >
             {projectType.label}
           </Row>
         ))


### PR DESCRIPTION
Small fix to a Key colour bug introduced earlier, alpha was added to the colours which has now been fixed.

Before:
<img width="592" alt="Screenshot 2023-01-26 at 16 59 35" src="https://user-images.githubusercontent.com/35331926/214901411-3eb51a06-2d1c-4420-8ea9-26f1d231395e.png">

After:
<img width="592" alt="Screenshot 2023-01-26 at 17 01 41" src="https://user-images.githubusercontent.com/35331926/214901527-e7961503-f53e-44fd-a69e-bd6e8d7acc18.png">
